### PR TITLE
Fixed: Can't use list as a method name in PHP5 as it's a reserved word

### DIFF
--- a/services.routing.yml
+++ b/services.routing.yml
@@ -36,7 +36,7 @@ entity.service_endpoint.resources:
   path: '/admin/structure/service_endpoint/{service_endpoint}/resources'
   defaults:
     _title: 'Service resources'
-    _controller: \Drupal\services\Controller\ServiceEndpointResources::list
+    _controller: \Drupal\services\Controller\ServiceEndpointResources::displayList
   requirements:
     _permission: 'manage services'
   options:

--- a/src/Controller/ServiceEndpointResources.php
+++ b/src/Controller/ServiceEndpointResources.php
@@ -46,7 +46,7 @@ class ServiceEndpointResources extends ControllerBase {
    * @return array
    *   An renderable array.
    */
-  public function list(ServiceEndpointInterface $service_endpoint = NULL) {
+  public function displayList(ServiceEndpointInterface $service_endpoint = NULL) {
     $build = [];
 
     foreach ($this->getCategoryDefinitions($service_endpoint) as $category => $definitions) {


### PR DESCRIPTION
This was a bug that was introduced in my last PR. 
